### PR TITLE
Remove deprecated unittest.TestCase.assert_()

### DIFF
--- a/pyutil/test/current/json_tests/test_decode.py
+++ b/pyutil/test/current/json_tests/test_decode.py
@@ -8,10 +8,10 @@ from pyutil import jsonutil as json
 class TestDecode(TestCase):
     def test_decimal(self):
         rval = json.loads('1.1', parse_float=decimal.Decimal)
-        self.assert_(isinstance(rval, decimal.Decimal))
+        self.assertIsInstance(rval, decimal.Decimal)
         self.assertEqual(rval, decimal.Decimal('1.1'))
 
     def test_float(self):
         rval = json.loads('1', parse_int=float)
-        self.assert_(isinstance(rval, float))
+        self.assertIsInstance(rval, float)
         self.assertEqual(rval, 1.0)

--- a/pyutil/test/current/json_tests/test_speedups.py
+++ b/pyutil/test/current/json_tests/test_speedups.py
@@ -10,11 +10,11 @@ class TestSpeedups(TestCase):
         if not encoder.c_encode_basestring_ascii:
             raise SkipTest("no C extension speedups available to test")
         self.assertEqual(decoder.scanstring.__module__, "simplejson._speedups")
-        self.assert_(decoder.scanstring is decoder.c_scanstring)
+        self.assertIs(decoder.scanstring, decoder.c_scanstring)
 
     def test_encode_basestring_ascii(self):
         if not encoder.c_encode_basestring_ascii:
             raise SkipTest("no C extension speedups available to test")
         self.assertEqual(encoder.encode_basestring_ascii.__module__, "simplejson._speedups")
-        self.assert_(encoder.encode_basestring_ascii is
+        self.assertIs(encoder.encode_basestring_ascii,
                           encoder.c_encode_basestring_ascii)


### PR DESCRIPTION
Replace `unittest.TestCase.assert_()` which has been removed in Python 3.12.

Fixes: #10 